### PR TITLE
Fix GITHUB-2282 testResult.getTestContext() return null when @BeforeM…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 Current
+6.14.13
+Fixed: GITHUB-2282 testResult.getTestContext() return null when @BeforeMethod failed(Dianny Chen)
+
 6.14.12
 Fixed: GITHUB-2089: Make ISuiteListener, ITestListener, IInvokedMethodListener, IConfigurationListener execute in the order of insertion (Yehui Wang)
 

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -489,7 +489,6 @@ public class Invoker implements IInvoker {
     if (noListenersPresent()) {
       return;
     }
-
     InvokedMethodListenerInvoker invoker = new InvokedMethodListenerInvoker(listenerMethod, testResult, m_testContext);
 //    for (IInvokedMethodListener currentListener : m_invokedMethodListeners) {
 //      invoker.invokeListener(currentListener, invokedMethod);
@@ -536,15 +535,15 @@ public class Invoker implements IInvoker {
     invokeConfigurations(testClass, tm, setupConfigMethods, suite, params, parameterValues, instance, testResult);
 
     InvokedMethod invokedMethod = new InvokedMethod(instance, tm, System.currentTimeMillis(), testResult);
-
     if (!confInvocationPassed(tm, tm, testClass, instance)) {
       Throwable exception = ExceptionUtils.getExceptionDetails(m_testContext, instance);
       ITestResult result = registerSkippedTestResult(tm, instance, System.currentTimeMillis(), exception);
+
       m_notifier.addSkippedTest(tm, result);
       tm.incrementCurrentInvocationCount();
       testResult.setMethod(tm);
-      runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
-      runInvokedMethodListeners(AFTER_INVOCATION, invokedMethod, testResult);
+            runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, result);
+            runInvokedMethodListeners(AFTER_INVOCATION, invokedMethod, result);
       ITestNGMethod[] teardownConfigMethods = TestNgMethodUtils.filterLastTimeRunnableTeardownConfigurationMethods(tm, afterMethods);
       invokeConfigurations(testClass, tm, teardownConfigMethods, suite, params, parameterValues, instance, testResult);
       invokeAfterGroupsConfigurations(tm, groupMethods, suite, params, instance);

--- a/src/main/java/org/testng/internal/Version.java
+++ b/src/main/java/org/testng/internal/Version.java
@@ -2,7 +2,7 @@ package org.testng.internal;
 
 public class Version {
 
-    public static final String VERSION = "DEV-SNAPSHOT-42c0d2037678cb862-6.14.12";
+    public static final String VERSION = "DEV-SNAPSHOT-42c0d2037678cb862-6.14.13";
 
     public static String getVersionString() {
         return VERSION;

--- a/src/test/java/test/Testcontext/CustomListener.java
+++ b/src/test/java/test/Testcontext/CustomListener.java
@@ -1,0 +1,30 @@
+package test.Testcontext;
+
+import static org.testng.Assert.assertNotNull;
+
+import org.testng.Assert;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.asserts.IAssert;
+
+public class CustomListener implements IInvokedMethodListener {
+
+    public static String s = "";
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        ITestContext dependsOn = testResult.getTestContext();
+        if (dependsOn == null) {
+            s = "null";
+        }
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+        ITestContext tct = testResult.getTestContext();
+        if (tct == null) {
+            s = "null";
+        }
+    }
+}

--- a/src/test/java/test/Testcontext/TestClass.java
+++ b/src/test/java/test/Testcontext/TestClass.java
@@ -1,0 +1,21 @@
+package test.Testcontext;
+
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+
+@Listeners(CustomListener.class)
+public class TestClass {
+
+    @BeforeClass
+    public void beforeMethod1() {
+        throw new SkipException("Skip happened at beforeMethod");
+    }
+
+    @Test
+    public void test() {
+        System.out.println("test is skiped");
+    }
+}

--- a/src/test/java/test/Testcontext/TestContextInListenerTest.java
+++ b/src/test/java/test/Testcontext/TestContextInListenerTest.java
@@ -1,0 +1,22 @@
+package test.Testcontext;
+
+
+import org.assertj.core.api.Assertions;
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.asserts.Assertion;
+
+import test.SimpleBaseTest;
+import test.annotationtransformer.SimpleTest;
+
+public class TestContextInListenerTest extends SimpleBaseTest {
+
+    @Test
+    public void test1() {
+        TestNG tng = create(TestClass.class);
+        tng.run();
+        Assert.assertTrue(!CustomListener.s.contains("null"));
+    }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -886,5 +886,10 @@
     </classes>
   </test>
 
+ <test name="TestContextTest">
+    <classes>
+      <class name="test.Testcontext.TestContextInListenerTest"/>
+    </classes>
+  </test>
 </suite>
 


### PR DESCRIPTION
…ethod failed

Fixes #2282 testResult.getTestContext() return null when @BeforeMethod fails

### Did you remember to?

- [ Yes] Add test case(s) 

- [Yes ] Update `CHANGES.txt`


We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
