### PR TITLE
Fix GITHUB-2282 testResult.getTestContext() return null when @BeforeMethod failed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 Current
+6.14.13
+Fixed GITHUB-2282 testResult.getTestContext() return null when @BeforeMethod failed (Dianny Chen)
+
 6.14.12
 Fixed: GITHUB-2089: Make ISuiteListener, ITestListener, IInvokedMethodListener, IConfigurationListener execute in the order of insertion (Yehui Wang)
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ task wrapper(type: Wrapper) {
 }
 
 group = 'org.testng'
-version = '6.14.12'
+version = '6.14.13'
 
 apply plugin: 'java'
 apply plugin: 'groovy'

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -543,8 +543,8 @@ public class Invoker implements IInvoker {
       m_notifier.addSkippedTest(tm, result);
       tm.incrementCurrentInvocationCount();
       testResult.setMethod(tm);
-      runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
-      runInvokedMethodListeners(AFTER_INVOCATION, invokedMethod, testResult);
+            runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, result);
+            runInvokedMethodListeners(AFTER_INVOCATION, invokedMethod, result);
       ITestNGMethod[] teardownConfigMethods = TestNgMethodUtils.filterLastTimeRunnableTeardownConfigurationMethods(tm, afterMethods);
       invokeConfigurations(testClass, tm, teardownConfigMethods, suite, params, parameterValues, instance, testResult);
       invokeAfterGroupsConfigurations(tm, groupMethods, suite, params, instance);

--- a/src/main/java/org/testng/internal/Version.java
+++ b/src/main/java/org/testng/internal/Version.java
@@ -2,7 +2,7 @@ package org.testng.internal;
 
 public class Version {
 
-    public static final String VERSION = "DEV-SNAPSHOT-42c0d2037678cb862-6.14.12";
+    public static final String VERSION = "DEV-SNAPSHOT-42c0d2037678cb862-6.14.13";
 
     public static String getVersionString() {
         return VERSION;

--- a/src/test/java/test/testcontext/CustomListener.java
+++ b/src/test/java/test/testcontext/CustomListener.java
@@ -1,0 +1,31 @@
+package test.testcontext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+
+public class CustomListener implements IInvokedMethodListener {
+
+    static List<String> s = new ArrayList<>();
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        ITestContext dependsOn = testResult.getTestContext();
+        if (dependsOn == null) {
+            s.add("null");
+        }
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+        ITestContext tct = testResult.getTestContext();
+        if (tct == null) {
+            s.add("null");
+        }
+    }
+
+}

--- a/src/test/java/test/testcontext/TestClass.java
+++ b/src/test/java/test/testcontext/TestClass.java
@@ -1,0 +1,21 @@
+package test.testcontext;
+
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(CustomListener.class)
+public class TestClass {
+
+    @BeforeClass
+    public void beforeMethod1() {
+        throw new SkipException("Skip happened at beforeMethod");
+    }
+
+    @Test
+    public void test() {
+        System.out.println("test is skiped");
+
+    }
+}

--- a/src/test/java/test/testcontext/TestContestInListenerTest.java
+++ b/src/test/java/test/testcontext/TestContestInListenerTest.java
@@ -1,0 +1,18 @@
+package test.testcontext;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import test.SimpleBaseTest;
+
+
+public class TestContestInListenerTest extends SimpleBaseTest {
+
+    @Test
+    public void test1() {
+        TestNG tng = create(TestClass.class);
+        tng.run();
+        Assert.assertTrue(!CustomListener.s.contains("null"), "testcontext return null is not excepted");
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -886,5 +886,10 @@
     </classes>
   </test>
 
+<test name="TestContest">
+    <classes>
+      <class name="test.testcontext.TestContestInListenerTest"/>
+    </classes>
+  </test>
 </suite>
 


### PR DESCRIPTION
Fixes # 2282

### Did you remember to?

- [Y ] Add test case(s)
- [Y ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
