### PR TITLE
get parent suite name before suite starts.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 Current
+6.14.14
+Fixed get parent suite name before suite starts.
+
 6.14.13
 Fixed GITHUB-2282 testResult.getTestContext() return null when @BeforeMethod failed (Dianny Chen)
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ task wrapper(type: Wrapper) {
 }
 
 group = 'org.testng'
-version = '6.14.13'
+version = '6.14.14'
 
 apply plugin: 'java'
 apply plugin: 'groovy'

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -182,6 +182,7 @@ public class TestNG {
   private boolean isSuiteInitialized = false;
   private org.testng.internal.ExitCodeListener exitCodeListener;
   private ExitCode exitCode;
+  public static Collection<XmlSuite> allSuites;
 
   /**
    * Default constructor. Setting also usage of default listeners/reporters.
@@ -292,7 +293,7 @@ public class TestNG {
       LOGGER.debug("suiteXmlPath: \"" + suitePath + "\"");
     }
     try {
-      Collection<XmlSuite> allSuites = Parser.parse(suitePath, getProcessor());
+      allSuites = Parser.parse(suitePath, getProcessor());
 
       for (XmlSuite s : allSuites) {
         if (this.m_parallelMode != null) {
@@ -1980,6 +1981,13 @@ public class TestNG {
     return Lists.newArrayList(serviceLoaderListeners.values());
   }
 
+  public String getSuiteName() {
+     String suitename = null;
+     for (XmlSuite s : allSuites) {
+         suitename = s.getName();
+     }
+     return suitename;
+  }
   //
   // ServiceLoader testing
   /////

--- a/src/main/java/org/testng/internal/Version.java
+++ b/src/main/java/org/testng/internal/Version.java
@@ -2,7 +2,7 @@ package org.testng.internal;
 
 public class Version {
 
-    public static final String VERSION = "DEV-SNAPSHOT-42c0d2037678cb862-6.14.13";
+    public static final String VERSION = "DEV-SNAPSHOT-01e7fb59fb43af3b-6.14.14";
 
     public static String getVersionString() {
         return VERSION;


### PR DESCRIPTION
Fixes # get parent suite name before suite starts.

### Did you remember to?

- [ ] Add test case(s)
- [Y ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
